### PR TITLE
feat: getAllVariations specify what variations get returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ export default defineNuxtConfig({
   const singleFlag = getVariationByKey(USER,   FLAG_KEY)
   // get a specified variation for the provided user with detail
   const singleFlagDetail = getVariationDetail(USER,   FLAG_KEY)
+  // get multiple variations
+  // if you are using any of the functions provided by the
+  // composable more than once per component, don't forget to
+  // pass a unique key to ensure that data fetching can be
+  // properly de-duplicated across requests
+  const pickFlags = getAllVariations(USER, [FLAG_KEY, 'second-key', 'third-key'], 'unique-key')
+
 </script>
 ```
 

--- a/cypress/integration/index.cjs
+++ b/cypress/integration/index.cjs
@@ -42,4 +42,19 @@ describe('@mftc/nuxt-launch-darkly', () => {
     cy.get('[data-test=all-variants-error]').should('contain', 'Error: null')
     cy.get('[data-test=all-variants-data]').should('not.contain', 'Data: null')
   })
+
+  it('should fetch and render result from getAllVariations with includeKey set', () => {
+    cy.get('[data-test=all-variants-pick-pending]').should(
+      'contain',
+      'Pending: false'
+    )
+    cy.get('[data-test=all-variants-pick-error]').should(
+      'contain',
+      'Error: null'
+    )
+    cy.get('[data-test=all-variants-pick-data]').should(
+      'not.contain',
+      'Data: null'
+    )
+  })
 })

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -28,6 +28,14 @@
         <p data-test="all-variants-error">Error: {{ allFlags.error }}</p>
         <p data-test="all-variants-data">Data: {{ allFlags.data }}</p>
       </div>
+      <h4>All flags pick items</h4>
+      <div>
+        <p data-test="all-variants-pick-pending">
+          Pending: {{ pickFlag.pending }}
+        </p>
+        <p data-test="all-variants-pick-error">Error: {{ pickFlag.error }}</p>
+        <p data-test="all-variants-pick-data">Data: {{ pickFlag.data }}</p>
+      </div>
     </section>
   </div>
 </template>
@@ -45,5 +53,6 @@ const { getAllVariations, getVariationByKey, getVariationDetail } =
 
 const singleFlag = getVariationByKey(USER, FLAG_KEY)
 const singleFlagDetail = getVariationDetail(USER, FLAG_KEY)
-const allFlags = getAllVariations(USER)
+const allFlags = getAllVariations(USER, undefined, 'key1')
+const pickFlag = getAllVariations(USER, [FLAG_KEY], 'key2')
 </script>

--- a/src/runtime/composables/useLaunchDarkly.ts
+++ b/src/runtime/composables/useLaunchDarkly.ts
@@ -1,9 +1,5 @@
-import {
-  LDEvaluationDetail,
-  LDFlagsState,
-  LDUser
-} from 'launchdarkly-node-server-sdk'
-import { useRuntimeConfig, useFetch } from '#app'
+import { LDEvaluationDetail, LDUser } from 'launchdarkly-node-server-sdk'
+import { useRuntimeConfig, useFetch, AsyncData } from '#app'
 
 export interface LDVariation {
   variation: boolean
@@ -13,11 +9,21 @@ export const useLaunchDarkly = () => {
   /**
    * Fetches all the variations for the provided user
    * @param user LDUser
+   * @param includeKeys Specify which variant keys you want returned. If undefined, all keys will be returned.
+   * @param key A unique key to ensure that data fetching can be properly de-duplicated across requests.
+   * Use if getAllVariations is used more than once per component
+   * @returns
    */
-  const getAllVariations = (user: LDUser) => {
+  const getAllVariations = (
+    user: LDUser,
+    includeKeys?: string[],
+    key?: string
+  ) => {
     const { launchDarkly } = useRuntimeConfig()
-    const res = useFetch<LDFlagsState>(launchDarkly.apiPath, {
-      params: user
+    const res = useFetch<Map<string, boolean>>(launchDarkly.apiPath, {
+      params: user,
+      pick: includeKeys,
+      ...(key && { key })
     })
     return res
   }
@@ -26,15 +32,20 @@ export const useLaunchDarkly = () => {
    * Fetches a single variation for the provided user
    * @param user LDUser
    * @param flagKey string
+   * @param defaultValue boolean
+   * @param key A unique key to ensure that data fetching can be properly de-duplicated across requests.
+   * Use if getVariationByKey is used more than once per component
    */
   const getVariationByKey = (
     user: LDUser,
     flagKey: string,
-    defaultValue: boolean = false
+    defaultValue: boolean = false,
+    key?: string
   ) => {
     const { launchDarkly } = useRuntimeConfig()
     const res = useFetch<LDVariation>(`${launchDarkly.apiPath}/${flagKey}`, {
-      params: { ...user, defaultValue: defaultValue.toString() }
+      params: { ...user, defaultValue: defaultValue.toString() },
+      ...(key && { key })
     })
     return res
   }
@@ -43,17 +54,22 @@ export const useLaunchDarkly = () => {
    * Fetches a single variation for the provided user with detail
    * @param user LDUser
    * @param flagKey string
+   * @param defaultValue boolean
+   * @param key A unique key to ensure that data fetching can be properly de-duplicated across requests.
+   * Use if getVariationByKey is used more than once per component
    */
   const getVariationDetail = (
     user: LDUser,
     flagKey: string,
-    defaultValue: boolean = false
+    defaultValue: boolean = false,
+    key?: string
   ) => {
     const { launchDarkly } = useRuntimeConfig()
     const res = useFetch<LDEvaluationDetail>(
       `${launchDarkly.apiPath}/${flagKey}/detail`,
       {
-        params: { ...user, defaultValue: defaultValue.toString() }
+        params: { ...user, defaultValue: defaultValue.toString() },
+        ...(key && { key })
       }
     )
     return res

--- a/src/runtime/launch-darkly.plugin.ts
+++ b/src/runtime/launch-darkly.plugin.ts
@@ -1,6 +1,6 @@
 import { LDUser } from 'launchdarkly-node-server-sdk'
-import { useLaunchDarkly } from './composables/useLaunchDarkly'
 import { defineNuxtPlugin } from '#app'
+import { useLaunchDarkly } from './composables/useLaunchDarkly'
 
 const { getAllVariations, getVariationByKey } = useLaunchDarkly()
 


### PR DESCRIPTION
- Add ability to specify what variations get returned from getAllVariations

```
const pickFlags = getAllVariations(USER, [FLAG_KEY, 'second-key', 'third-key'], 'unique-key')
```
- Add unique key for `useFetch`
- Remove `$flagsState` and `$valid` from `getAllVariations` response